### PR TITLE
Correction of chronograph count generation

### DIFF
--- a/R/Chronograph.R
+++ b/R/Chronograph.R
@@ -110,13 +110,16 @@ getChronographData <- function(connectionDetails,
   }
   periodLength <- 30
   numberOfPeriods <- 72
-  periodStarts <- seq(from = 1 - periodLength * numberOfPeriods/2,
-                      to = 1 + periodLength * (-1 + numberOfPeriods/2),
-                      by = periodLength)
-  periodEnds <- periodStarts + periodLength - 1
+  periodStarts <- c(
+    seq(-periodLength*numberOfPeriods/2L, -1L, by=periodLength),
+    0L,
+    seq(1L, 1L + periodLength * (-1L + numberOfPeriods/2L), by=periodLength)
+  )
+  periodEnds <- periodStarts + periodLength - 1L
+  periodEnds[periodStarts==0L] <- 0L
   periods <- data.frame(periodStart = periodStarts,
                         periodEnd = periodEnds,
-                        periodId = 1:numberOfPeriods - numberOfPeriods/2 - 1)
+                        periodId = c((-numberOfPeriods/2L):(-1L),0L,1L:(numberOfPeriods/2L)))
   periodsForDb <- periods
   colnames(periodsForDb) <- SqlRender::camelCaseToSnakeCase(colnames(periodsForDb))
   


### PR DESCRIPTION
This PR has two parts:

- The R function getChronographData() in Chronograph.R used to generate time periods that were incorrect, or at least not as intended in the method. Period 0 should consist only of a single day (day 0), and neither time period -1 nor 1 should include day 0. (Effectively, when we say that we want to use 72 periods for the 36 months prior and after exposure, we really want 72+1 time periods, to account for time period 0, which is special.)

- The SQL code that generated the chronograph counts in CreateChronographData.sql used to exclude time periods with zero counts. I have proposed a fix that may not be the most elegant, but that seems to do the work. When the tables #exposure_outcome and #outcome are generated, I have added a bit of code that first creates all relevant combinations of outcome ids and period ids (and exposure ids for #exposure_outcome). Those bits are then LEFT JOINed with the previous code that generates the actual counts, and NULL counts are replaced by zero.

The second fix has the nice side effect that the plotting of the chronographs never breaks down or gets weird due to periods with missing data.

It does seem like the generation of the counts is way too slow unless one restricts the background to specific exposures and/or outcomes. I am looking into how that could be solved as well.